### PR TITLE
Switch to standalone prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "rimraf": "^2.4.3"
   },
   "dependencies": {
+    "prop-types": "^15.5.8",
     "react": ">=0.14.2"
   }
 }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,6 @@
 import invariant from 'invariant';
-import React, { PropTypes as RPT } from 'react';
+import React from 'react';
+import { PropTypes as RPT } from 'prop-types';
 
 export default class Script extends React.Component {
 


### PR DESCRIPTION
In React 16, `PropTypes` will no longer be available in the main React package. It has been moved to the standalone [prop-types](https://www.npmjs.com/package/prop-types) package. As of React v. 15.5.0, accessing `PropTypes` from the main React package throws a warning.

This pull request includes makes the necessary changes to ready this package for React 16, while remaining backward compatible.

Please let me know if you have questions or would like changes. Thanks.