### PR TITLE
fix: async prop set directly vs via Element.setAttribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Called when the requested script is fully loaded.
 URL pointing to the script you want to load.
 
 ### `attributes`
-An object used to define custom attributes to be set on the script element. For example, `attributes={{ id: 'someId', 'data-custom: 'value' }}` will result in `<script id="someId" data-custom="value" />`
+An object used to define custom attributes to be set on the script element. For example, `attributes={{ id: 'someId', 'data-custom: 'value' }}` will result in `<script id="someId" data-custom="value" />`. To set `async=false`, specify in `attributes` like so: `attributes={{ async: 'false', ... }}`. 
 
 ## Example
 You can use the following code to load jQuery in your app:

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -90,8 +90,9 @@ export default class Script extends React.Component {
 
     script.src = url;
     
-    // default async to true if not set with custom attributes
-    if (!script.hasAttribute('async')) {
+    if (script.hasAttribute('async') && script.getAttribute('async') === 'false') {
+      script.async = false;
+    } else {
       script.async = 1;
     }
 

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -17,7 +17,7 @@ beforeEach(() => {
       id: 'dummyId',
       dummy: 'non standard',
       'data-dummy': 'standard',
-      async: false,
+      async: 'false',
     },
   };
   wrapper = shallow(<Script {...props} />);


### PR DESCRIPTION
Oops, sorry. Fixed.