### PR TITLE
Pass error event to `onError` callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The package exports a single component with the following props:
 Called as soon as the script tag is created.
 
 ### `onError` (required)
-Called in case of an error with the script.
+Called in case of an error with the script. Will receive the generated error event as an argument.
 
 ### `onLoad` (required)
 Called when the requested script is fully loaded.
@@ -52,8 +52,8 @@ handleScriptCreate() {
   this.setState({ scriptLoaded: false })
 }
 
-handleScriptError() {
-  this.setState({ scriptError: true })
+handleScriptError(errorEvent) {
+  this.setState({ scriptError: true, scriptErrorEvent: errorEvent })
 }
 
 handleScriptLoad() {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -49,7 +49,8 @@ export default class Script extends React.Component {
     }
 
     if (this.constructor.erroredScripts[url]) {
-      onError();
+      const errorEvent = this.constructor.erroredScripts[url];
+      onError(errorEvent);
       return;
     }
 
@@ -111,10 +112,10 @@ export default class Script extends React.Component {
       });
     };
 
-    script.onerror = () => {
-      this.constructor.erroredScripts[url] = true;
+    script.onerror = (errorEvent) => {
+      this.constructor.erroredScripts[url] = errorEvent;
       callObserverFuncAndRemoveObserver((observer) => {
-        observer.onError();
+        observer.onError(errorEvent);
         return true;
       });
     };

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -54,9 +54,12 @@ test('componentDidMount should not run onLoad callback if script not yet loaded'
 });
 
 test('componentDidMount should run onError callback if script has errored', () => {
-  wrapper.instance().constructor.erroredScripts[props.url] = true;
+  const errorEvent = { type: 'error' };
+  wrapper.instance().constructor.erroredScripts[props.url] = errorEvent;
   wrapper.instance().componentDidMount();
   expect(props.onError.mock.calls.length).toBe(1);
+  expect(props.onError.mock.calls[0].length).toBe(1);
+  expect(props.onError.mock.calls[0][0]).toBe(errorEvent);
 });
 
 test('componentDidMount should not run onError callback if script has not errored', () => {


### PR DESCRIPTION
I'd like to be able to inspect the event generated in case of an error with the script, so I'm passing it to the component error callback.